### PR TITLE
Using hours instead of days notation

### DIFF
--- a/examples/backup/run.sh
+++ b/examples/backup/run.sh
@@ -4,7 +4,7 @@
 # You may need to use a different tool if start-stop-daemon is not available for your Linux distribution.
 
 # Example crontab entry:
-# 0 */2 * * * /path/to/backup/run.sh BUCKET BUCKET_PREFIX REPLICA_ID 30d
+# 0 */2 * * * /path/to/backup/run.sh BUCKET BUCKET_PREFIX REPLICA_ID 720h
 # Every two hours, this will backup, delete backups older than 30 days, and garbage collect
 
 BUCKET=$1


### PR DESCRIPTION
It's a very small fix but I've been facing with this some time ago.

The thing is the example says that you should use `30d` to delete backups older than 30 days but `30d` notation is not supported by Go, the valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
So if you try to call strata with `30d` (or something like that) you will get a beautiful exception:

```
2016/03/28 09:30:37 Starting strata driver
panic: time: unknown unit d in duration 30d
```

The PR purpose is only convert one month time to hours in order to not change the example behavior. 
