### PR TITLE
Local storage List() searches recursively

### DIFF
--- a/strata/storage_testing.go
+++ b/strata/storage_testing.go
@@ -19,10 +19,13 @@ func HelpTestStorage(t *testing.T, s Storage) {
 
 	data1 := []byte("abcdef")
 	data2 := strings.NewReader("xyz123")
+	data3 := []byte("ijklmn")
 
 	err := s.Put("a/data1", data1)
 	ensure.Nil(t, err)
 	err = s.PutReader("b/data2", data2)
+	ensure.Nil(t, err)
+	err = s.Put("c/subc/data3", data3)
 	ensure.Nil(t, err)
 
 	items, err := s.List("a", 1000)
@@ -33,26 +36,43 @@ func HelpTestStorage(t *testing.T, s Storage) {
 	ensure.Nil(t, err)
 	ensure.DeepEqual(t, len(items), 1)
 	ensure.SameElements(t, items, []string{"b/data2"})
+	items, err = s.List("c", 1000)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, len(items), 1)
+	ensure.SameElements(t, items, []string{"c/subc/data3"})
+	items, err = s.List("c/subc", 1000)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, len(items), 1)
+	ensure.SameElements(t, items, []string{"c/subc/data3"})
 
 	data1Reader, err := s.Get("a/data1")
 	ensure.Nil(t, err)
 	data2Reader, err := s.Get("b/data2")
 	ensure.Nil(t, err)
+	data3Reader, err := s.Get("c/subc/data3")
 
 	content, err := ioutil.ReadAll(data1Reader)
 	ensure.Nil(t, err)
 	ensure.DeepEqual(t, content, []byte("abcdef"))
-
 	content, err = ioutil.ReadAll(data2Reader)
 	ensure.Nil(t, err)
 	ensure.DeepEqual(t, content, []byte("xyz123"))
+	content, err = ioutil.ReadAll(data3Reader)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, content, []byte("ijklmn"))
 
 	err = s.Delete("a/data1")
 	ensure.Nil(t, err)
 	err = s.Delete("b/data2")
 	ensure.Nil(t, err)
+	err = s.Delete("c/subc/data3")
+	ensure.Nil(t, err)
 
 	items, err = s.List("", 1000)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, len(items), 0)
+
+	items, err = s.List("nonexistent", 1000)
 	ensure.Nil(t, err)
 	ensure.DeepEqual(t, len(items), 0)
 }


### PR DESCRIPTION
And, List() called on a non-existent directory returns an empty list
with no error.

This is the same behavior as remote storage List().

Hopefully, this helps create a local replica + local storage driver.

Test plan: Added to the storage unit test
