### PR TITLE
Boolean flags can't have default values

### DIFF
--- a/strata/driver.go
+++ b/strata/driver.go
@@ -370,7 +370,7 @@ func (c *ShowReplicaIDsCommand) Execute(args []string) error {
 type ShowBackupsCommand struct {
 	driverFactory DriverFactory
 	ReplicaID     string `short:"r" long:"replica-id" description:"The replica ID to show backups for" required:"true"`
-	ShowSize      []bool `short:"s" long:"show-size" optional:"true" description:"Print backup size with backup ids"`
+	ShowSize      bool   `short:"s" long:"show-size" description:"Print backup size with backup ids"`
 }
 
 // Execute calls ListBackups to implement "show backups"
@@ -379,11 +379,7 @@ func (c *ShowBackupsCommand) Execute(args []string) error {
 	if err != nil {
 		panic(err)
 	}
-	showSize := false
-	if len(c.ShowSize) > 0 {
-		showSize = true
-	}
-	if err := driver.ListBackups(c.ReplicaID, showSize); err != nil {
+	if err := driver.ListBackups(c.ReplicaID, c.ShowSize); err != nil {
 		panic(err)
 	}
 	return nil

--- a/strata/mongo/mongoq.go
+++ b/strata/mongo/mongoq.go
@@ -464,7 +464,7 @@ func startMongoQ(driver *strata.Driver, mountPath string, showSize bool, mongodP
 // Options relevant to extended mongo shell
 type Options struct {
 	MountPath  string `short:"m" long:"mount-path" description:"Wrapped mongo shell will look for database files at mount-path. You could set up this path with yas3fs." required:"true"`
-	ShowSize   bool   `short:"s" long:"show-size" default:"false" description:"Print backup size with backup ids"`
+	ShowSize   bool   `short:"s" long:"show-size" description:"Print backup size with backup ids"`
 	MongodPath string `long:"mongod-path" default:"mongod" description:"path to mongod executable"`
 	MongoPath  string `long:"mongo-path" default:"mongo" description:"path to mongo executable"`
 }


### PR DESCRIPTION
go-flags discards commands that have boolean flags with default values,
so remove the default values. Booleans defaults to `false` if their flag
is absent.

The go-flags behavior is caused by by
https://github.com/jessevdk/go-flags/commit/7f2ab82552ae1b12e070838918ac056507c0f114
in the go-flags library and mentioned in
https://github.com/facebookgo/rocks-strata/issues/25. We used
https://github.com/facebookgo/rocks-strata/commit/993df44c1b2d02a088a10532df05b1e453042607
as a workaround.

This diff fixes a problem where mongoq options would disappear and also cleans
up our previous workaround.

Test plan: Compile strata driver and mongoq driver and check that
 `./strata show backups --help` and `./mongoq --help` display the show-size
option.
