### PR TITLE
Add ability to backup to Azure blob storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: go
 
 env:
-    # Set to true when a MongoRocks environment is set up
-    - USING_MONGO_3X=false
-    # Set to true when Azure Storage Emulator is running on localhost:10000
-    - USING_AZURE_STORAGE_EMULATOR=false
+    # Set USING_MONGO_3X to true when a MongoRocks environment is set up
+    # Set USING_AZURE_STORAGE_EMULATOR to true when Azure Storage Emulator is running on localhost:10000
+    - USING_MONGO_3X=false USING_AZURE_STORAGE_EMULATOR=false
 
 go:
     - 1.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ env:
     - USING_MONGO_3X=false
 
 go:
-    - 1.4
-    - 1.5
+    - 1.7
     - tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: go
 env:
     # Set to true when a MongoRocks environment is set up
     - USING_MONGO_3X=false
+    # Set to true when Azure Storage Emulator is running on localhost:10000
+    - USING_AZURE_STORAGE_EMULATOR=false
 
 go:
     - 1.7

--- a/strata/azureblobstorage/mock_storage.go
+++ b/strata/azureblobstorage/mock_storage.go
@@ -1,1 +1,43 @@
 package azureblobstorage
+
+import (
+	"testing"
+	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/facebookgo/ensure"
+	"math/rand"
+	"fmt"
+)
+
+
+type AzureMock struct {
+	azureEmulator *AzureBlobStorage
+}
+
+func (azureMock *AzureMock) Start(t *testing.T) {
+	azureMock.azureEmulator.blobStorageClient.DeleteContainerIfExists(azureMock.azureEmulator.containerName)
+	azureMock.azureEmulator.blobStorageClient.CreateContainer(azureMock.azureEmulator.containerName, storage.ContainerAccessTypePrivate)
+}
+
+func (azureMock *AzureMock) Stop() {
+}
+
+func NewMockAzure(t *testing.T) *AzureMock {
+	azureEmulatorClient, err := storage.NewEmulatorClient()
+	ensure.Nil(t, err)
+
+	blobService := azureEmulatorClient.GetBlobService()
+
+	blobMock := AzureBlobStorage {
+		blobStorageClient: &blobService,
+		client: &azureEmulatorClient,
+		containerName: fmt.Sprintf("testcontainer%d", rand.Intn(100000)), //Randomizing since the container in the emulator is "finally" consistent
+		prefix: "",
+	}
+
+	m := AzureMock {
+		azureEmulator: &blobMock,
+	}
+
+	m.Start(t)
+	return &m
+}

--- a/strata/azureblobstorage/mock_storage.go
+++ b/strata/azureblobstorage/mock_storage.go
@@ -1,13 +1,13 @@
 package azureblobstorage
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
+
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/facebookgo/ensure"
-	"math/rand"
-	"fmt"
 )
-
 
 type AzureMock struct {
 	azureEmulator *AzureBlobStorage
@@ -27,14 +27,14 @@ func NewMockAzure(t *testing.T) *AzureMock {
 
 	blobService := azureEmulatorClient.GetBlobService()
 
-	blobMock := AzureBlobStorage {
+	blobMock := AzureBlobStorage{
 		blobStorageClient: &blobService,
-		client: &azureEmulatorClient,
-		containerName: fmt.Sprintf("testcontainer%d", rand.Intn(100000)), //Randomizing since the container in the emulator is "finally" consistent
-		prefix: "",
+		client:            &azureEmulatorClient,
+		containerName:     fmt.Sprintf("testcontainer%d", rand.Intn(100000)), //Randomizing since the container in the emulator is "finally" consistent
+		prefix:            "",
 	}
 
-	m := AzureMock {
+	m := AzureMock{
 		azureEmulator: &blobMock,
 	}
 

--- a/strata/azureblobstorage/mock_storage.go
+++ b/strata/azureblobstorage/mock_storage.go
@@ -1,0 +1,1 @@
+package azureblobstorage

--- a/strata/azureblobstorage/storage.go
+++ b/strata/azureblobstorage/storage.go
@@ -1,23 +1,24 @@
 package azureblobstorage
 
 import (
+	"encoding/base64"
+	"fmt"
 	"io"
 	"math"
-	"fmt"
-	"encoding/base64"
 
-	"github.com/Azure/azure-sdk-for-go/storage"
 	"io/ioutil"
 	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/storage"
 )
 
 const MAX_BLOCK_SIZE = 1024 * 1024 * 4 // 4MB
 
 type AzureBlobStorage struct {
-	client *storage.Client
+	client            *storage.Client
 	blobStorageClient *storage.BlobStorageClient
-	containerName string
-	prefix string
+	containerName     string
+	prefix            string
 }
 
 func (azureBlob *AzureBlobStorage) addPrefix(path string) string {
@@ -52,10 +53,10 @@ func NewAzureBlobStorage(accountName string, accountKey string, containerName st
 	}
 
 	return &AzureBlobStorage{
-		client: &azureClient,
+		client:            &azureClient,
 		blobStorageClient: &blobClient,
-		containerName: containerName,
-		prefix: prefix,
+		containerName:     containerName,
+		prefix:            prefix,
 	}, nil
 }
 
@@ -73,7 +74,7 @@ func (azureBlob *AzureBlobStorage) Put(path string, data []byte) error {
 		block_id := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%10d", i)))
 
 		min_data_range := i * MAX_BLOCK_SIZE
-		max_data_range := int(math.Min(float64((i + 1) * MAX_BLOCK_SIZE), float64(data_length)))
+		max_data_range := int(math.Min(float64((i+1)*MAX_BLOCK_SIZE), float64(data_length)))
 
 		data_slice := data[min_data_range:max_data_range]
 
@@ -114,7 +115,7 @@ func (azureBlob *AzureBlobStorage) List(prefix string, maxSize int) ([]string, e
 	items := make([]string, 0, 1000)
 	for remaining_size > 0 {
 		contents, err := azureBlob.blobStorageClient.ListBlobs(azureBlob.containerName,
-			storage.ListBlobsParameters{ Prefix: prefix, Delimiter: pathSeparator, Marker: marker, MaxResults: uint(remaining_size) })
+			storage.ListBlobsParameters{Prefix: prefix, Delimiter: pathSeparator, Marker: marker, MaxResults: uint(remaining_size)})
 
 		if err != nil {
 			return nil, err

--- a/strata/azureblobstorage/storage.go
+++ b/strata/azureblobstorage/storage.go
@@ -7,13 +7,11 @@ import (
 	"encoding/base64"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
-	"github.com/facebookgo/rocks-strata/strata"
-	"encoding/hex"
 	"io/ioutil"
 	"strings"
 )
 
-const MAX_BLOCK_SIZE = 1024 * 1024 * 1024 * 100 // 100MB
+const MAX_BLOCK_SIZE = 1024 * 1024 * 4 // 4MB
 
 type AzureBlobStorage struct {
 	client *storage.Client
@@ -23,10 +21,18 @@ type AzureBlobStorage struct {
 }
 
 func (azureBlob *AzureBlobStorage) addPrefix(path string) string {
+	if len(azureBlob.prefix) == 0 {
+		return path // Do not append "/" in the start of the path
+	}
+
 	return azureBlob.prefix + "/" + path
 }
 
 func (azureBlob *AzureBlobStorage) removePrefix(path string) string {
+	if len(azureBlob.prefix) == 0 {
+		return path // Do not remove the first chars if we didn't append any.
+	}
+
 	return path[len(azureBlob.prefix)+1:]
 }
 
@@ -54,25 +60,7 @@ func NewAzureBlobStorage(accountName string, accountKey string, containerName st
 }
 
 func (azureBlob *AzureBlobStorage) Get(path string) (io.ReadCloser, error) {
-	props, err := azureBlob.blobStorageClient.GetBlobProperties(azureBlob.containerName, path)
-	if err != nil {
-		return nil, err
-	}
-
-	etag := props.Etag
-
-	reader, err := azureBlob.blobStorageClient.GetBlob(azureBlob.containerName, path)
-
-	if reader == nil || err != nil {
-		return nil, err
-	}
-
-	checksum, err := hex.DecodeString(etag)
-	if err != nil {
-		return nil, err
-	}
-
-	return strata.NewChecksummingReader(reader, checksum), nil
+	return azureBlob.blobStorageClient.GetBlob(azureBlob.containerName, path)
 }
 
 func (azureBlob *AzureBlobStorage) Put(path string, data []byte) error {
@@ -121,35 +109,28 @@ func (azureBlob *AzureBlobStorage) List(prefix string, maxSize int) ([]string, e
 	prefix = azureBlob.addPrefix(prefix)
 	pathSeparator := ""
 	marker := ""
+	remaining_size := maxSize
 
 	items := make([]string, 0, 1000)
-	for maxSize > 0 {
-		// Don't ask for more than 1000 keys at a time. This makes
-		// testing simpler because S3 will return at most 1000 keys even if you
-		// ask for more, but s3test will return more than 1000 keys if you ask
-		// for more. TODO(agf): Fix this behavior in s3test.
-		maxReqSize := 1000
-		if maxSize < 1000 {
-			maxReqSize = maxSize
-		}
-
+	for remaining_size > 0 {
 		contents, err := azureBlob.blobStorageClient.ListBlobs(azureBlob.containerName,
-			storage.ListBlobsParameters{ Prefix: prefix, Delimiter: pathSeparator, Marker: marker, MaxResults: uint(maxReqSize) })
+			storage.ListBlobsParameters{ Prefix: prefix, Delimiter: pathSeparator, Marker: marker, MaxResults: uint(remaining_size) })
 
 		if err != nil {
 			return nil, err
 		}
-		maxSize -= maxReqSize
+
+		remaining_size -= len(contents.Blobs)
 
 		for _, key := range contents.Blobs {
 			items = append(items, azureBlob.removePrefix(key.Name))
 		}
 
-		if len(items) == maxReqSize {
-			marker = contents.NextMarker
-		} else {
-			break;
+		if len(contents.NextMarker) == 0 { // We're done
+			break
 		}
+
+		marker = contents.NextMarker
 	}
 
 	return items, nil

--- a/strata/azureblobstorage/storage.go
+++ b/strata/azureblobstorage/storage.go
@@ -1,0 +1,144 @@
+package azureblobstorage
+
+import (
+	"io"
+
+	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/facebookgo/rocks-strata/strata"
+	"encoding/hex"
+	"io/ioutil"
+	"strings"
+)
+
+type AzureBlobStorage struct {
+	client *storage.Client
+	blobStorageClient *storage.BlobStorageClient
+	containerName string
+	prefix string
+}
+
+func (azureBlob *AzureBlobStorage) addPrefix(path string) string {
+	return azureBlob.prefix + "/" + path
+}
+
+func (azureBlob *AzureBlobStorage) removePrefix(path string) string {
+	return path[len(azureBlob.prefix)+1:]
+}
+
+func NewAzureBlobStorage(accountName string, accountKey string, containerName string, prefix string) (*AzureBlobStorage, error) {
+	azureClient, err := storage.NewBasicClient(accountName, accountKey)
+	if err != nil {
+		return nil, err
+	}
+
+	blobClient := azureClient.GetBlobService()
+
+	err = blobClient.CreateContainer(containerName, storage.ContainerAccessTypePrivate)
+	if err != nil {
+		if !strings.Contains(err.Error(), "The specified container already exists.") {
+			return nil, err
+		}
+	}
+
+	return &AzureBlobStorage{
+		client: &azureClient,
+		blobStorageClient: &blobClient,
+		containerName: containerName,
+		prefix: prefix,
+	}, nil
+}
+
+func (azureBlob *AzureBlobStorage) Get(path string) (io.ReadCloser, error) {
+	path = azureBlob.addPrefix(path)
+
+	props, err := azureBlob.blobStorageClient.GetBlobProperties(azureBlob.containerName, path)
+	if err != nil {
+		return nil, err
+	}
+
+	etag := props.Etag
+
+	reader, err := azureBlob.blobStorageClient.GetBlob(azureBlob.containerName, path)
+
+	if reader == nil || err != nil {
+		return nil, err
+	}
+
+	checksum, err := hex.DecodeString(etag)
+	if err != nil {
+		return nil, err
+	}
+
+	return strata.NewChecksummingReader(reader, checksum), nil
+}
+
+func (azureBlob *AzureBlobStorage) Put(path string, data []byte) error {
+	path = azureBlob.addPrefix(path)
+
+	err := azureBlob.blobStorageClient.PutBlock(azureBlob.containerName, path, "0", data)
+
+	return err
+}
+
+func (azureBlob *AzureBlobStorage) PutReader(path string, reader io.Reader) error {
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	return azureBlob.Put(path, data)
+}
+
+func (azureBlob *AzureBlobStorage) Delete(path string) error {
+	path = azureBlob.addPrefix(path)
+	err := azureBlob.blobStorageClient.DeleteBlob(azureBlob.containerName, path, map[string]string{})
+	return err
+}
+
+func (azureBlob *AzureBlobStorage) List(prefix string, maxSize int) ([]string, error) {
+	prefix = azureBlob.addPrefix(prefix)
+	pathSeparator := ""
+	marker := ""
+
+	items := make([]string, 0, 1000)
+	for maxSize > 0 {
+		// Don't ask for more than 1000 keys at a time. This makes
+		// testing simpler because S3 will return at most 1000 keys even if you
+		// ask for more, but s3test will return more than 1000 keys if you ask
+		// for more. TODO(agf): Fix this behavior in s3test.
+		maxReqSize := 1000
+		if maxSize < 1000 {
+			maxReqSize = maxSize
+		}
+
+		contents, err := azureBlob.blobStorageClient.ListBlobs(azureBlob.containerName,
+			storage.ListBlobsParameters{ Prefix: prefix, Delimiter: pathSeparator, Marker: marker, MaxResults: uint(maxReqSize) })
+
+		if err != nil {
+			return nil, err
+		}
+		maxSize -= maxReqSize
+
+		for _, key := range contents.Blobs {
+			items = append(items, azureBlob.removePrefix(key.Name))
+		}
+
+		if len(items) == maxReqSize {
+			marker = contents.NextMarker
+		} else {
+			break;
+		}
+	}
+
+	return items, nil
+
+}
+
+// Lock is not implemented
+func (azureBlob *AzureBlobStorage) Lock(path string) error {
+	return nil
+}
+
+// Unlock is not implemented
+func (azureBlob *AzureBlobStorage) Unlock(path string) error {
+	return nil
+}

--- a/strata/azureblobstorage/storage_test.go
+++ b/strata/azureblobstorage/storage_test.go
@@ -1,0 +1,1 @@
+package azureblobstorage

--- a/strata/azureblobstorage/storage_test.go
+++ b/strata/azureblobstorage/storage_test.go
@@ -1,9 +1,10 @@
 package azureblobstorage
 
 import (
-	"testing"
-	"github.com/facebookgo/rocks-strata/strata"
 	"os"
+	"testing"
+
+	"github.com/facebookgo/rocks-strata/strata"
 )
 
 func TestAzureStorage(t *testing.T) {

--- a/strata/azureblobstorage/storage_test.go
+++ b/strata/azureblobstorage/storage_test.go
@@ -1,1 +1,23 @@
 package azureblobstorage
+
+import (
+"testing"
+"github.com/facebookgo/rocks-strata/strata"
+)
+
+func TestAzureStorage(t *testing.T) {
+	t.Parallel()
+	azure := NewMockAzure(t)
+	defer azure.Stop()
+
+	strata.HelpTestStorage(t, azure.azureEmulator)
+}
+
+func TestAzureStorageManyFiles(t *testing.T) {
+	t.Parallel()
+	azure := NewMockAzure(t)
+	defer azure.Stop()
+
+	strata.HelpTestStorageManyFiles(t, azure.azureEmulator)
+
+}

--- a/strata/azureblobstorage/storage_test.go
+++ b/strata/azureblobstorage/storage_test.go
@@ -3,9 +3,14 @@ package azureblobstorage
 import (
 	"testing"
 	"github.com/facebookgo/rocks-strata/strata"
+	"os"
 )
 
 func TestAzureStorage(t *testing.T) {
+	if os.Getenv("USING_AZURE_STORAGE_EMULATOR") != "true" {
+		t.Skip("Skipping test. Set USING_AZURE_STORAGE_EMULATOR=true to run.")
+	}
+
 	t.Parallel()
 	azure := NewMockAzure(t)
 	defer azure.Stop()
@@ -14,6 +19,10 @@ func TestAzureStorage(t *testing.T) {
 }
 
 func TestAzureStorageManyFiles(t *testing.T) {
+	if os.Getenv("USING_AZURE_STORAGE_EMULATOR") != "true" {
+		t.Skip("Skipping test. Set USING_AZURE_STORAGE_EMULATOR=true to run.")
+	}
+
 	t.Parallel()
 	azure := NewMockAzure(t)
 	defer azure.Stop()

--- a/strata/azureblobstorage/storage_test.go
+++ b/strata/azureblobstorage/storage_test.go
@@ -1,8 +1,8 @@
 package azureblobstorage
 
 import (
-"testing"
-"github.com/facebookgo/rocks-strata/strata"
+	"testing"
+	"github.com/facebookgo/rocks-strata/strata"
 )
 
 func TestAzureStorage(t *testing.T) {

--- a/strata/cmd/mongo/lreplica_drivers/lrazureblobdriver/lrazureblobdriver.go
+++ b/strata/cmd/mongo/lreplica_drivers/lrazureblobdriver/lrazureblobdriver.go
@@ -10,7 +10,6 @@ import (
 	"github.com/facebookgo/rocks-strata/strata/azureblobstorage"
 )
 
-// AWSOptions are common to all commands
 type AzureBlobOptions struct {
 	Container string `short:"C" long:"container" description:"Azure Blob Storage container name" required:"true"`
 	BlobPrefix string `short:"p" long:"blob-prefix" description:"Prefix used when storing and retrieving files. Optional" optional:"true"`

--- a/strata/cmd/mongo/lreplica_drivers/lrazureblobdriver/lrazureblobdriver.go
+++ b/strata/cmd/mongo/lreplica_drivers/lrazureblobdriver/lrazureblobdriver.go
@@ -6,12 +6,12 @@ import (
 	"strconv"
 
 	"github.com/facebookgo/rocks-strata/strata"
-	"github.com/facebookgo/rocks-strata/strata/mongo/lreplica"
 	"github.com/facebookgo/rocks-strata/strata/azureblobstorage"
+	"github.com/facebookgo/rocks-strata/strata/mongo/lreplica"
 )
 
 type AzureBlobOptions struct {
-	Container string `short:"C" long:"container" description:"Azure Blob Storage container name" required:"true"`
+	Container  string `short:"C" long:"container" description:"Azure Blob Storage container name" required:"true"`
 	BlobPrefix string `short:"p" long:"blob-prefix" description:"Prefix used when storing and retrieving files. Optional" optional:"true"`
 }
 
@@ -25,8 +25,8 @@ type ReplicaOptions struct {
 
 // Options define the common options needed by this strata command
 type Options struct {
-	AzureBlobOptions AzureBlobOptions  `group:"Azure Blob Options"`
-	Replica 	 ReplicaOptions    `group:"Replica Options"`
+	AzureBlobOptions AzureBlobOptions `group:"Azure Blob Options"`
+	Replica          ReplicaOptions   `group:"Replica Options"`
 }
 
 // DriverFactory implements strata.DriverFactory
@@ -73,4 +73,3 @@ func (factory DriverFactory) Driver() (*strata.Driver, error) {
 	}
 	return &strata.Driver{Manager: manager}, err
 }
-

--- a/strata/cmd/mongo/lreplica_drivers/lrazureblobdriver/lrazureblobdriver.go
+++ b/strata/cmd/mongo/lreplica_drivers/lrazureblobdriver/lrazureblobdriver.go
@@ -1,0 +1,77 @@
+package lrazureblobdriver
+
+import (
+	"errors"
+	"os"
+	"strconv"
+
+	"github.com/facebookgo/rocks-strata/strata"
+	"github.com/facebookgo/rocks-strata/strata/mongo/lreplica"
+	"github.com/facebookgo/rocks-strata/strata/azureblobstorage"
+)
+
+// AWSOptions are common to all commands
+type AzureBlobOptions struct {
+	Container string `short:"C" long:"container" description:"Azure Blob Storage container name" required:"true"`
+	BlobPrefix string `short:"p" long:"blob-prefix" description:"Prefix used when storing and retrieving files. Optional" optional:"true"`
+}
+
+// ReplicaOptions are used for commands like backup and restore
+type ReplicaOptions struct {
+	MaxBackgroundCopies int    `long:"max-background-copies" default:"16" description:"Backup and restore actions will use up to this many goroutines to copy files"`
+	Port                int    `long:"port" default:"27017" description:"Backup should look for a mongod instance that is listening on this port"`
+	Username            string `long:"username" description:"If auth is configured, specify the username with admin privileges here"`
+	Password            string `long:"password" description:"Password for the specified user."`
+}
+
+// Options define the common options needed by this strata command
+type Options struct {
+	AzureBlobOptions AzureBlobOptions  `group:"Azure Blob Options"`
+	Replica 	 ReplicaOptions    `group:"Replica Options"`
+}
+
+// DriverFactory implements strata.DriverFactory
+type DriverFactory struct {
+	Ops *Options
+}
+
+// GetOptions returns the factory's Options
+func (factory DriverFactory) GetOptions() interface{} {
+	return factory.Ops
+}
+
+// Driver uses the DriverFactory's Options to construct a strata.Driver
+func (factory DriverFactory) Driver() (*strata.Driver, error) {
+	options := factory.GetOptions().(*Options)
+
+	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
+	accountSecret := os.Getenv("AZURE_ACCOUNT_SECRET")
+	if accountName == "" || accountSecret == "" {
+		return nil, errors.New("Environment variables AZURE_ACCOUNT_NAME and AZURE_ACCOUNT_SECRET must be set")
+	}
+
+	azureBloblStorage, err := azureblobstorage.NewAzureBlobStorage(
+		accountName,
+		accountSecret,
+		options.AzureBlobOptions.Container,
+		options.AzureBlobOptions.BlobPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	replica, err := lreplica.NewLocalReplica(
+		options.Replica.MaxBackgroundCopies,
+		strconv.Itoa(options.Replica.Port),
+		options.Replica.Username,
+		options.Replica.Password,
+	)
+	if err != nil {
+		return nil, err
+	}
+	manager, err := strata.NewSnapshotManager(replica, azureBloblStorage)
+	if err != nil {
+		return nil, err
+	}
+	return &strata.Driver{Manager: manager}, err
+}
+

--- a/strata/cmd/mongo/lreplica_drivers/strata/main.go
+++ b/strata/cmd/mongo/lreplica_drivers/strata/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/facebookgo/rocks-strata/strata/cmd/mongo/lreplica_drivers/lrminiodriver"
 	"github.com/facebookgo/rocks-strata/strata/cmd/mongo/lreplica_drivers/lrs3driver"
 	"github.com/facebookgo/rocks-strata/strata/cmd/mongo/lreplica_drivers/lrldriver"
+	"github.com/facebookgo/rocks-strata/strata/cmd/mongo/lreplica_drivers/lrazureblobdriver"
 )
 
 func main() {
@@ -26,6 +27,8 @@ func main() {
 		strata.RunCLI(lrminiodriver.DriverFactory{Ops: &lrminiodriver.Options{}})
 	case "local":
 		strata.RunCLI(lrldriver.DriverFactory{Ops: &lrldriver.Options{}})
+	case "azureblob":
+		strata.RunCLI(lrazureblobdriver.DriverFactory{Ops: &lrazureblobdriver.Options{}})
 	default:
 		strata.RunCLI(lrs3driver.DriverFactory{Ops: &lrs3driver.Options{}})
 	}

--- a/strata/cmd/mongo/lreplica_drivers/strata/main.go
+++ b/strata/cmd/mongo/lreplica_drivers/strata/main.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 
 	"github.com/facebookgo/rocks-strata/strata"
+	"github.com/facebookgo/rocks-strata/strata/cmd/mongo/lreplica_drivers/lrazureblobdriver"
+	"github.com/facebookgo/rocks-strata/strata/cmd/mongo/lreplica_drivers/lrldriver"
 	"github.com/facebookgo/rocks-strata/strata/cmd/mongo/lreplica_drivers/lrminiodriver"
 	"github.com/facebookgo/rocks-strata/strata/cmd/mongo/lreplica_drivers/lrs3driver"
-	"github.com/facebookgo/rocks-strata/strata/cmd/mongo/lreplica_drivers/lrldriver"
-	"github.com/facebookgo/rocks-strata/strata/cmd/mongo/lreplica_drivers/lrazureblobdriver"
 )
 
 func main() {


### PR DESCRIPTION
This PR adds the ability to backup to blob storage.
It also contains tests that are very similar to the S3 ones -

Couple of issues:

1. There are no good mocking libraries for Azure blob storage for Go lang.
So currently, in order to run the tests you will need the Azure Storage Emulator (https://docs.microsoft.com/en-us/azure/storage/storage-use-emulator) - meaning that tests (but only tests) will only run on Windows.
I'm also working on making this work with azurite (https://github.com/arafato/azurite) so that the tests could run on any platform.

2. Azure go SDK supports only go 1.7 & up (Updated travis file) - not sure if backwards compatibility with go 1.6 and down is important for you.

In any case - it's tested and working properly, tested with smaller and larger replica sets.