### PR TITLE
Fix minio PutObject

### DIFF
--- a/strata/miniostorage/storage.go
+++ b/strata/miniostorage/storage.go
@@ -72,7 +72,7 @@ func (m *MinioStorage) Get(name string) (io.ReadCloser, error) {
 func (m *MinioStorage) Put(name string, data []byte) error {
 
 	path := m.addPrefix(name)
-	_, err := m.minio.PutObject(m.bucket, path, bytes.NewReader(data), "application/octet-stream")
+	_, err := m.minio.PutObject(m.bucket, path, bytes.NewReader(data), int64(len(data)), &minio.PutObjectOptions{ContentType: "application/octet-stream"})
 
 	return err
 }


### PR DESCRIPTION
This commit: https://github.com/minio/minio-go/commit/f98a667ab5d283564aa82ac0aec08dcf34b4e5bb broke rocks-strata (Doesn't compile).
This is a PR to use the new interface.