### PR TITLE
Fix strata build updating minio putObject and getObject api methods

### DIFF
--- a/strata/miniostorage/storage.go
+++ b/strata/miniostorage/storage.go
@@ -60,7 +60,7 @@ func NewMinioStorage(endPoint, accessKeyID, secretAccessKey, bucket, prefix, reg
 func (m *MinioStorage) Get(name string) (io.ReadCloser, error) {
 
 	path := m.addPrefix(name)
-	obj, err := m.minio.GetObject(m.bucket, path)
+	obj, err := m.minio.GetObject(m.bucket, path, minio.GetObjectOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (m *MinioStorage) Get(name string) (io.ReadCloser, error) {
 func (m *MinioStorage) Put(name string, data []byte) error {
 
 	path := m.addPrefix(name)
-	_, err := m.minio.PutObject(m.bucket, path, bytes.NewReader(data), "application/octet-stream")
+	_, err := m.minio.PutObject(m.bucket, path, bytes.NewReader(data), int64(len(data)), minio.PutObjectOptions{ContentType: "application/octet-stream"})
 
 	return err
 }


### PR DESCRIPTION
**Gist:**
This is just follow up with earlier PR #36, saw @AdallomRoy  inactive in his github profile :smiley: 

**Changes Made:**
  Since strata was failing to compile, so just updated 2 lines regard to minion objects operations [putObject](https://docs.minio.io/docs/golang-client-api-reference#PutObject) and [getObject](https://docs.minio.io/docs/golang-client-api-reference#GetObject) like in updated docs.

I am not sure how to trigger travis in my fork, so creating a new PR to check the build :neckbeard: 

@AGFeldman 
/cc @AdallomRoy  